### PR TITLE
Minor change to controls

### DIFF
--- a/batteryPercent.c
+++ b/batteryPercent.c
@@ -51,7 +51,7 @@ int checkButtons(int port, tai_hook_ref_t ref_hook, SceCtrlData *ctrl, int count
 		{
 			pressed_buttons = ctrl->buttons & ~old_buttons;
 
-			if ((ctrl->buttons & SCE_CTRL_SELECT) && (ctrl->buttons & SCE_CTRL_DOWN))
+			if ((ctrl->buttons & SCE_CTRL_SELECT) && (ctrl->buttons & SCE_CTRL_LTRIGGER))
 				showMenu = 0;
 
 			old_buttons = ctrl->buttons;

--- a/batteryPercent.c
+++ b/batteryPercent.c
@@ -51,16 +51,17 @@ int checkButtons(int port, tai_hook_ref_t ref_hook, SceCtrlData *ctrl, int count
 		{
 			pressed_buttons = ctrl->buttons & ~old_buttons;
 
-			if ((ctrl->buttons & SCE_CTRL_SELECT) && ((ctrl->buttons & SCE_CTRL_LEFT) || (ctrl->buttons & SCE_CTRL_DOWN)))
+			if ((ctrl->buttons & SCE_CTRL_SELECT) && (ctrl->buttons & SCE_CTRL_DOWN))
 				showMenu = 0;
 
 			old_buttons = ctrl->buttons;
 			
 			//ctrl->buttons = 0; //Disable controls
+			//changed button configs to prevent overlap with oclockvita
 		}
 		else
 		{
-			if ((ctrl->buttons & SCE_CTRL_SELECT) && (ctrl->buttons & SCE_CTRL_UP))
+			if ((ctrl->buttons & SCE_CTRL_SELECT) && (ctrl->buttons & SCE_CTRL_LEFT))
 				showMenu = 1;
 			else if ((ctrl->buttons & SCE_CTRL_SELECT) && (ctrl->buttons & SCE_CTRL_RIGHT))
 				showMenu = 2;


### PR DESCRIPTION
Small change so that Select + Left and Select + Right activate percentage and time remaining, respectively. Select + L-Trigger deactivates. Prevents overlapping controls with other plugins, like oclockvita. I was going to make the changes just for my own use, but it looks like there's an open issue from someone mentioning the same thing so I figured I'd just post it up anyway. 

Thanks